### PR TITLE
Stream Error Handling: reading invalid wav file

### DIFF
--- a/pychedelic/stream.py
+++ b/pychedelic/stream.py
@@ -161,7 +161,10 @@ iter.next = iter.__next__ # Compatibility Python 2
 class read_wav(object):
 
     def __init__(self, filelike, start=0, end=None):
-        self.wfile, self.infos = wav.open_read_mode(filelike)
+        try:
+            self.wfile, self.infos = wav.open_read_mode(filelike)
+        except:
+            raise InvalidFileError('File "%s" is invalid' % filelike)
         self.end = end
         self.seek(start)
         self.frames_read = 0
@@ -268,3 +271,9 @@ def _until_StopIteration():
         yield
     except StopIteration:
         pass
+
+class InvalidFileError(Exception):
+    """
+    Raised when attempting to read a wave file failed.
+    """
+    pass

--- a/tests/stream_tests.py
+++ b/tests/stream_tests.py
@@ -8,6 +8,7 @@ import scipy.io.wavfile as sp_wavfile
 
 from .__init__ import A440_MONO_16B, A440_STEREO_16B, STEPS_MONO_16B
 from pychedelic import stream
+from pychedelic.stream import InvalidFileError
 from pychedelic import config
 from pychedelic.core import wav as core_wav
 
@@ -495,6 +496,9 @@ class read_wav_Test(unittest.TestCase):
     def tearDown(self):
         config.frame_rate = 44100
         config.block_size = 1024
+
+    def invalid_file_test(self):
+        self.assertRaises(InvalidFileError, stream.read_wav, 'broken')
 
     def blocks_size_test(self):
         config.block_size = 50


### PR DESCRIPTION
This PR contains new error handling in `stream.read_wav`:
- Throws error if `read_wav` is given an invalid file:

**Example:**

``` python
stream.read_wav('broken')

InvalidFileError: File "broken" is invalid
```

resolves #5 
